### PR TITLE
Raise if save fails, even when there are no errors

### DIFF
--- a/dm-noisy-failures.gemspec
+++ b/dm-noisy-failures.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
                   "completed."
   s.license     = "MIT"
 
+  s.add_dependency "data_mapper"
   s.add_dependency "dm-core"
   s.add_dependency "dm-validations"
   s.files        = Dir["{lib}/**/*.rb"]

--- a/dm-noisy-failures.gemspec
+++ b/dm-noisy-failures.gemspec
@@ -13,7 +13,8 @@ Gem::Specification.new do |s|
                   "completed."
   s.license     = "MIT"
 
-  s.add_dependency "data_mapper"
+  s.add_dependency "dm-core"
+  s.add_dependency "dm-validations"
   s.files        = Dir["{lib}/**/*.rb"]
   s.require_path = "lib"
 end

--- a/lib/data_mapper/noisy_failures.rb
+++ b/lib/data_mapper/noisy_failures.rb
@@ -4,7 +4,7 @@ module DataMapper
     alias_method :destroy?, :destroy
 
     def save
-      return true if self.save? || self.errors.empty?
+      return true if self.save? && self.errors.empty?
       error_message = self.errors.map { |e| "#{self.class}: #{e.join(', ')}" }.join("; ")
       raise SaveFailureError.new(error_message, self)
     end

--- a/lib/data_mapper/noisy_failures/version.rb
+++ b/lib/data_mapper/noisy_failures/version.rb
@@ -1,5 +1,5 @@
 module DataMapper
   module NoisyFailures
-    VERSION = "0.2.3"
+    VERSION = "0.2.4"
   end
 end


### PR DESCRIPTION
Throw :halt in data mapper hooks causes saves to fail, but no errors in the list. Same does cascaded saving. At the moment, dm noisy failures makes this look like a success. Please fix and release a new version, your tool is awesome
